### PR TITLE
Fixing a 'key' error and an import error

### DIFF
--- a/models/ner.py
+++ b/models/ner.py
@@ -23,7 +23,9 @@ from transformers import (
 )
 from transformers import AdamW, get_linear_schedule_with_warmup
 
-from label_studio.ml import LabelStudioMLBase
+# from label_studio.ml import LabelStudioMLBase
+from label_studio_ml.model import LabelStudioMLBase
+
 from utils import calc_slope
 
 

--- a/models/ner.py
+++ b/models/ner.py
@@ -477,7 +477,7 @@ class TransformersBasedTagger(LabelStudioMLBase):
         texts, list_of_spans = [], []
         for item in completions:
             texts.append(item['data'][self.value])
-            list_of_spans.append(self.get_spans(item['completions'][0]))
+            list_of_spans.append(self.get_spans(item['annotations'][0]))
 
         logger.debug('Prepare dataset')
         pad_token_label_id = CrossEntropyLoss().ignore_index


### PR DESCRIPTION
When I tried to reproduce the results in __ner.py__ file, I had to fix two errors. One of them was a typo. Specifically, each *completion* (item) in _fit_ method expects key 'annotations'  (not 'completions') and that's what the author had intended. 
The other fix I had to make was not so obvious. Specifically, I see an import error with _LabelStudioMLBase_ and changing the module it was importing form fixed the error. I learned this by seeing a couple of other label-studio code examples.
I've not used _bert.py_ file, and can't speak for these fixes in that file.