### PR TITLE
Fix NER script:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Models
+/predictwhens


### PR DESCRIPTION
'ALL_MODELS' is not needed and 'pretrained_config_archive_map' is deprecated.

Fixed error in predictions for label-ends which lead to one label snaking the next one without accounting for 'O'-labels between them.